### PR TITLE
Add missing `win` to IO instance of CanFail

### DIFF
--- a/_posts/2017-01-07-how_do_type_classes_differ_from_interfaces.markdown
+++ b/_posts/2017-01-07-how_do_type_classes_differ_from_interfaces.markdown
@@ -389,6 +389,7 @@ instance CanFail IO where
                 return a
             Error exception ->
                 second
+    win a = return a
 ```
 
 Now, we can use our `safeDivision` function in `IO`, just like it were `print` or similar!


### PR DESCRIPTION
Should there be a `win` here?

Thanks for an otherwise interesting read!