### PR TITLE
Update 2018-03-26-stealing_where_from_rust.markdown

### DIFF
--- a/_posts/2018-03-26-stealing_where_from_rust.markdown
+++ b/_posts/2018-03-26-stealing_where_from_rust.markdown
@@ -68,7 +68,7 @@ anychar :: forall t.
         , Slice (FromRange Int), AtEof
         ]
      , AsChar (InputIterItem t)
-    => f a -> f a
+     ) => f a -> f a
 ```
 
 Nice.


### PR DESCRIPTION
I think it's missing a closing `)` here.