### PR TITLE
Fix mistakes in Type safety back and forth

### DIFF
--- a/_posts/2017-04-08-maybe_use_a_type_parameter.markdown
+++ b/_posts/2017-04-08-maybe_use_a_type_parameter.markdown
@@ -44,7 +44,7 @@ Consider this function that gets a user's comembers in the organization:
 ```haskell
 coworkers :: User -> Maybe [User]
 coworkers user = case userOrganization user of
-    Nothing -> 
+    Nothing ->
         Nothing
     Just organization ->
         Just (organizationUsers organization)
@@ -75,7 +75,7 @@ data DbPost = DbPost
     }
 
 type UserId = Text
-type OrganizationId = Text 
+type OrganizationId = Text
 type PostId = Text
 ```
 
@@ -125,7 +125,7 @@ type UserModel = User Organization
 type UserDb = User OrganizationId
 ```
 
-And now, our data model allows us to use the same type to describe these two use cases! 
+And now, our data model allows us to use the same type to describe these two use cases!
 So this is a small victory.
 We can take it a bit further, though -- why hardcode the `Maybe`ness of that organization?
 We've solved some of the boilerplate, but we still have the issue with `coworkers` returning a `Maybe`.
@@ -138,7 +138,7 @@ coworkers = fmap organizationUsers . userOrganization
 So, let's remove the `Maybe` from our definition, which moves the absence or presence of the organization from the value level to the type level.
 
 ```haskell
-data User org = User 
+data User org = User
     { userName :: Text
     , userOrganization :: org
     }
@@ -147,20 +147,20 @@ data User org = User
 Now, let's look at all of our cool variants!
 
 ```haskell
-type UserWithOrg 
+type UserWithOrg
     = User Organization
 
 type UserInDb      
     = User (Maybe OrganizationId)
 
-type UserWithOrgId 
+type UserWithOrgId
     = User OrganizationId
 
-type UserWithoutOrganization 
+type UserWithoutOrganization
     = User ()
 ```
 
-We can express some really neat stuff here. 
+We can express some really neat stuff here.
 Our type for `coworkers` is a lot nicer:
 
 ```haskell
@@ -169,7 +169,7 @@ coworkers = organizationUsers . userOrganization
 ```
 
 We're now disallowed from passing a `User` in unless we've already given that user an `Organization`.
-We've also gained a nice way of bottoming out our relationship: the `Organization` contains a list of users with organization referneces, instead of actual organizations.
+We've also gained a nice way of bottoming out our relationship: the `Organization` contains a list of users with organization references, instead of actual organizations.
 This makes it safe to print the whole thing out.
 
 We can also immediately see whether or not we need to do joins, inner joins, left joins, etc. because the nature of the relationship is specified in the type.
@@ -180,7 +180,7 @@ The functions for loading stuff out of the database is like:
 --   This is an ordinary select.
 loadUsers :: Database [User (Maybe OrganizationId)]
 loadUsers = execute [sql|
-    select users.* 
+    select users.*
     from users
     |]
 
@@ -188,9 +188,9 @@ loadUsers = execute [sql|
 --   This does an inner join.
 loadUsersWithOrganizations :: Database [User OrganizationId]
 loadUsersWithOrganizations = execute [sql|
-    select users.* 
-    from users 
-    inner join organizations 
+    select users.*
+    from users
+    inner join organizations
         on users.organization_id = organizations.id
     |]
 
@@ -199,11 +199,11 @@ loadUsersAndOrganizations :: Database [User Organization]
 loadUsersAndOrganizations = combine <$> execute [sql|
     select users.*, organizations.*
     from users
-    inner join organizations 
+    inner join organizations
         on users.organization_id = organizations.id
     |]
   where
-    combine user organization = 
+    combine user organization =
         user { userOrganization = organization }
 ```
 

--- a/_posts/2017-04-26-basic_type_level_programming_in_haskell.markdown
+++ b/_posts/2017-04-26-basic_type_level_programming_in_haskell.markdown
@@ -64,7 +64,7 @@ In fact, if we ask GHCi about it's type, we get this back:
 MkIntAndChar :: Int -> Char -> IntAndChar
 ```
 
-`MkIntAndChar` is a function accepting an `Int` and a `Char` and finally yeilding a value of type `IntAndChar`.
+`MkIntAndChar` is a function accepting an `Int` and a `Char` and finally yielding a value of type `IntAndChar`.
 
 So we can construct values, and values have types.
 Can we construct types?
@@ -481,8 +481,8 @@ Ahh, except now GHC is going to give us an error.
       In the type family declaration for ‘Add’
 ```
 
-GHC is extremely scared of undecidability, and won't do *anything* that it can't easily figure out on it's own. 
-`UndecidableInstances` is an extension which allows you to say: 
+GHC is extremely scared of undecidability, and won't do *anything* that it can't easily figure out on it's own.
+`UndecidableInstances` is an extension which allows you to say:
 
 > Look, GHC, it's okay. I know you can't figure this out. I promise this makes sense and will eventually terminate.
 
@@ -649,7 +649,7 @@ And in `append`s recursive case, we're building up the right hand side.
 Let's trace how this error happens, and supply some type annotations as well:
 
 ```haskell
-append (VCons a rest) xs = 
+append (VCons a rest) xs =
 ```
 
 Here, we know that `VCons a rest` has the type `Vector (Succ n) a`, and `xs` has the type `Vector m a`.
@@ -679,10 +679,10 @@ This new definition compiles and works fine.
 Agreed, which is why I'll defer the interested reader to [this much better tutorial](https://www.schoolofhaskell.com/user/konn/prove-your-haskell-for-great-safety/dependent-types-in-haskell) on length indexed vectors in Haskell.
 Instead, let's look at some other more interesting and practical examples of type level programming.
 
-# Heterogenous Lists
+# Heterogeneous Lists
 
-Heterogenous lists are kind of like tuples, but they're defined inductively.
-We keep a type level list of the contents of the heterogenous list, which let us operate safely on them.
+Heterogeneous lists are kind of like tuples, but they're defined inductively.
+We keep a type level list of the contents of the heterogeneous list, which let us operate safely on them.
 
 To use ordinary Haskell lists at the type level, we need another extension:
 
@@ -709,7 +709,7 @@ Let's see what a value for this looks like:
 
 ```haskell
 λ> :t 'a' ::: 1 ::: "hello" ::: HNil
-'a' ::: 1 ::: "hello" ::: HNil 
+'a' ::: 1 ::: "hello" ::: HNil
     :: HList '[Char, Int, String]
 ```
 
@@ -784,9 +784,9 @@ We've covered that base case.
 We'll assume that we can handle the smaller cases, and demonstrate how to handle a slightly large case:
 
 ```haskell
-instance (Show (HList as), Show a) 
+instance (Show (HList as), Show a)
     => Show (HList (a ': as)) where
-    show (a ::: rest) = 
+    show (a ::: rest) =
         show a ++ " ::: " ++ show rest
 ```
 
@@ -872,7 +872,7 @@ instance Show (HRec (s >> a ': xs)) where
 OK, so we need to `show` the `a` value. Easy. Which means we need a `Show a` constraint tacked onto our instance:
 
 ```haskell
-instance (Show a) 
+instance (Show a)
     => Show (HRec (s >> a ': xs)) where
     show (HCons (Named a) rest) =
         let val = show a
@@ -882,7 +882,7 @@ Next up, we need the key as a string.
 Which means we need to use `symbolVal`, which takes a `proxy s` and returns the `String` associated with the `s` provided that `s` is a `KnownSymbol`.
 
 ```haskell
-instance (Show a, KnownSymbol s) 
+instance (Show a, KnownSymbol s)
     => Show (HRec (s >> a ': xs)) where
     show (HCons (Named a) rest) =
         let val = show a
@@ -922,7 +922,7 @@ If we want for type variables to have a scope similar to other variables, we nee
 Finally, we need to show the rest of the stuff!
 
 ```haskell
-instance (Show a, KnownSymbol s, Show (HRec xs)) 
+instance (Show a, KnownSymbol s, Show (HRec xs))
     => Show (HRec (s >> a ': xs)) where
     show (HCons (Named a) rest) =
         let val = show a

--- a/_posts/2017-07-27-inverted_mocking.markdown
+++ b/_posts/2017-07-27-inverted_mocking.markdown
@@ -162,7 +162,7 @@ conduitThatGetsStuff = ...
 
 conduitThatProcessesStuff :: Conduit ByteString IO RealThing
 conduitThatProcessesStuff =
-  CL.mapM (\bs -> 
+  CL.mapM (\bs ->
     case parseFromByteString bs of
       Left err ->
         throwIO err
@@ -246,8 +246,8 @@ Given the above abstract definition, we can easily recover the concrete `doWork`
 
 ```haskell
 doWork :: App ()
-doWork = 
-  doWorkAbstract 
+doWork =
+  doWorkAbstract
     (runHTTP getUserQuery)
     (\query -> runDB (usersSatisfying query))
     (\user -> getSomething user)
@@ -258,7 +258,7 @@ We can also easily get a testing variant that logs the actions taken:
 
 ```haskell
 doWorkScribe :: Writer [String] ()
-doWorkScribe = 
+doWorkScribe =
   doWorkAbstract getQ getUsers getSomething redis
   where
     getQ = do
@@ -275,7 +275,7 @@ doWorkScribe =
       tell ["wrote v: " <> show v]
 ```
 
-All without having to fuss about with monad tranformers, type classes, or anything else that's terribly complicated.
+All without having to fuss about with monad transformers, type classes, or anything else that's terribly complicated.
 
 # Decompose!!!
 
@@ -318,15 +318,15 @@ class Monad m => GetUsers m where
 
 This is *vastly* more tenable interface to implement that a SQL database!
 Let's write our instances, one for the [`persistent` ](https://hackage.haskell.org/package/persistent) library and another for a mock that uses QuickCheck's `Gen` type:
-     
+
 ```haskell
 instance MonadIO m => GetUsers (SqlPersistT m) where
   runUserQuery = selectList . convertToQuery
 
 instance GetUsers Gen where
-  runUserQuery query = 
+  runUserQuery query =
     case query of
-      AllUsers -> 
+      AllUsers ->
         arbitrary
       UserById userId ->
         take 1 . fmap (setUserId userId) <$> arbitrary
@@ -348,9 +348,9 @@ A fixed variant looks like this:
 
 ```haskell
 instance GetUsers Gen where
-  runUserQuery query = 
+  runUserQuery query =
     case query of
-      AllUsers -> 
+      AllUsers ->
         arbitrary
       UserById userId -> do
         oneOrZero <- choose (0, 1)

--- a/_posts/2017-07-29-using_ghc_callstacks.markdown
+++ b/_posts/2017-07-29-using_ghc_callstacks.markdown
@@ -10,7 +10,7 @@ categories: programming
 Haskell doesn't really have a callstack.
 The evaluation strategy is more like a graph reduction.
 If you don't understand that, that's okay -- I don't either!
-All I know about it is that it makes questions like "what's the strack trace for this error?" surprisingly difficult to answer.
+All I know about it is that it makes questions like "what's the stack trace for this error?" surprisingly difficult to answer.
 
 While Haskell's debugging story tends to be rather nice (break up code into small, composable, reusable functions; take advantage of types to make errors unrepresentable where practical; write unit and property tests for the rest), it's also great to know where errors actually come from.
 Coding practices like "don't ever use partial functions like `head :: [a] -> a`" and "prefer `NonEmpty a` to `[a]` where possible" help a lot.
@@ -37,7 +37,7 @@ headWithCallstack (x:xs) = x
 headWithCallstack [] = error "nope"
 ```
 
-Let's compare the behavior of these various functions. 
+Let's compare the behavior of these various functions.
 The ordinary `head` from the Prelude gives us this:
 
 ```haskell
@@ -71,7 +71,7 @@ error ::
 The `:info` output shows that `error` is polymorphic in the runtime representation (eg: the phantom type `a` can be an unlifted type like `Int#` or a lifted type like `Int`).
 The `:type` omits the `HasCallStack` constraint for some reason.
 
-When `headWithCallstack` throws that error, you'll get more extra information: 
+When `headWithCallstack` throws that error, you'll get more extra information:
 
 ```
 λ> headWithCallStack []
@@ -181,4 +181,3 @@ Implicit parameters can potentially interact with sharing in weird ways, which m
 This makes them less useful.
 
 Lastly, the GHC Exceptions machinery doesn't have any notion of a callstack, and any *proper* exceptions that you throw or catch will not have a callstack: only `error` calls.
-

--- a/_posts/2017-10-11-type_safety_back_and_forth.markdown
+++ b/_posts/2017-10-11-type_safety_back_and_forth.markdown
@@ -14,7 +14,7 @@ data Maybe a
     | Just a
 ```
 
-We can use `Maybe` as the result of a function to indicate: 
+We can use `Maybe` as the result of a function to indicate:
 
 > Hey, friend! This function might fail. You'll need to handle the `Nothing` case.
 
@@ -75,22 +75,22 @@ We'll take advantage of Haskell's `PatternSynonyms` language extension to allow 
 ```haskell
 {-# LANGUAGE PatternSynonyms #-}
 
-module NonZero 
-  ( NonZero(getNonZero)
+module NonZero
+  ( NonZero(unNonZero)
   , pattern NonZero
   , nonZero
   ) where
 
 newtype NonZero a = UnsafeNonZero { unNonZero :: a }
 
-pattern NonZero a = UnsafeNonZero a
+pattern NonZero a <- UnsafeNonZero a
 
 nonZero :: (Num a, Eq a) => a -> Maybe (NonZero a)
 nonZero 0 = Nothing
 nonZero i = Just (UnsafeNonZero i)
 ```
 
-This module allows us to push the responsibilty for type safety backwards onto callers.
+This module allows us to push the responsibility for type safety backwards onto callers.
 
 As another example, consider `head`.
 Here's the unsafe, convenient variety:

--- a/_posts/2018-10-02-small_types.markdown
+++ b/_posts/2018-10-02-small_types.markdown
@@ -49,7 +49,7 @@ With `lookupJustified`, the `ph` type guarantees that the `Key` is present in th
 
 # Expansion and Restriction
 
-"Type Safety Back and Forth" uses the metaphor of "pushing" the responsibility in one of two directions: 
+"Type Safety Back and Forth" uses the metaphor of "pushing" the responsibility in one of two directions:
 
 - forwards: the caller of the function is responsible for handling the possible error output
 - backwards: the caller of the function is required to providing correct inputs
@@ -73,9 +73,9 @@ Let's consider the second technique.
 Specifically, here's `NonZero` and `NonEmpty`, two common ways to implement it:
 
 ```haskell
-newtype NonZero a 
-    = UnsafeNonZero 
-    { unNonZero :: a 
+newtype NonZero a
+    = UnsafeNonZero
+    { unNonZero :: a
     }
 
 nonZero :: (Num a, Eq a) => a -> Maybe (NonZero a)
@@ -136,7 +136,7 @@ In fact, for any function with a sufficiently precise type signature, there is a
 Joachim Breitner's [`justDoIt`](https://www.joachim-breitner.de/blog/735-The_magic_%E2%80%9CJust_do_it%E2%80%9D_type_class) is a fascinating utility that can solve these implementations for you.
 
 With sufficiently fancy types, the computer can write even more code for you.
-The programming language Idris can [write well-defined functions like `zipWith` and `tranpose` for length-indexed lists nearly automatically!](https://youtu.be/X36ye-1x_HQ?t=1140)
+The programming language Idris can [write well-defined functions like `zipWith` and `transpose` for length-indexed lists nearly automatically!](https://youtu.be/X36ye-1x_HQ?t=1140)
 
 # Restrict the Range
 

--- a/_posts/2018-11-03-capability_and_suitability.markdown
+++ b/_posts/2018-11-03-capability_and_suitability.markdown
@@ -21,7 +21,7 @@ Or, on the other end of the scale, you can opt for a truly fat tire at around 5"
 What's the difference?
 
 Narrower tires are less capable -- there is less terrain you can cover on a narrow tire.
-However, they're more suitable for the terrain they can cover -- a 19mm tire will be significantly lighter and faster thana 5" tire.
+However, they're more suitable for the terrain they can cover -- a 19mm tire will be significantly lighter and faster than a 5" tire.
 A good 19mm tire weighs around 200g, while a 5" tire might weigh 1,800g each.
 Lugging around an extra 7lbs of rubber takes a lot of energy!
 Additionally, all that rubber is going to have a lot of rolling resistance -- it'll be harder to push across the ground on smooth surfaces where the 19mm tire excels.

--- a/_posts/2018-11-03-trouble_with_typed_errors.markdown
+++ b/_posts/2018-11-03-trouble_with_typed_errors.markdown
@@ -35,7 +35,7 @@ data LookupError = KeyWasNotPresent
 
 lookup :: k -> Map k v -> Either LookupError v
 
-data ParseError 
+data ParseError
     = UnexpectedChar Char String
     | RanOutOfInput
 
@@ -97,9 +97,9 @@ mapLeft _ r = r
 Now, we can combine these error types:
 
 ```haskell
-foo :: String 
-    -> Either 
-        (Either HeadError (Either LookupError ParseError)) 
+foo :: String
+    -> Either
+        (Either HeadError (Either LookupError ParseError))
         Integer
 foo str = do
     c <- mapLeft Left (head str)
@@ -134,7 +134,7 @@ foo str = do
 ```
 
 However, there's a pretty major problem with this code.
-`foo` is claiming that it can "throw" all kinds of errors -- it's being honest about parse errors, lookup errors, and head erors, but it's also claiming that it will throw if files aren't found, "whatever" happens,  and `etc`.
+`foo` is claiming that it can "throw" all kinds of errors -- it's being honest about parse errors, lookup errors, and head errors, but it's also claiming that it will throw if files aren't found, "whatever" happens,  and `etc`.
 There's no way that a call to `foo` will result in `FileNotFound`, because `foo` can't even do `IO`!
 It's absurd.
 The type is too large!
@@ -145,9 +145,9 @@ We call the function, and then write a case expression like good Haskellers:
 
 ```haskell
 case foo "hello world" of
-    Right val -> 
+    Right val ->
         pure val
-    Left err -> 
+    Left err ->
         case err of
             AllParseError parseError ->
                 handleParseError parseError
@@ -171,7 +171,7 @@ Let's suppose we know how to handle a case or two of the error, but we must pass
 
 ```haskell
 bar :: String -> Either AllErrorsEver Integer
-bar str = 
+bar str =
     case foo str of
         Right val -> Right val
         Left err ->
@@ -186,7 +186,7 @@ We *know* that `AllParseError` has been handled by `bar`, because -- just look a
 However, the compiler has no idea.
 Whenever we inspect the error content of `bar`, we must either a) "handle" an error case that has already been handled, perhaps dubiously, or b) ignore the error, and desperately hope that no underlying code ever ends up throwing the error.
 
-Are we done with the probles on this approach?
+Are we done with the problems on this approach?
 No!
 There's no guarantee that I throw the *right* error!
 
@@ -226,9 +226,9 @@ r = Right
 Now, let's refactor that uglier `Either` code with these new helpers:
 
 ```haskell
-foo :: String 
-    -> Either 
-        (HeadError + LookupError + ParseError) 
+foo :: String
+    -> Either
+        (HeadError + LookupError + ParseError)
         Integer
 foo str = do
     c <- mapLeft l (head str)
@@ -271,8 +271,8 @@ head :: AsHeadError err => [a] -> Either err a
 lookup :: k -> Map k v -> Either LookupError v
 
 -- Prismatic:
-lookup 
-    :: (AsLookupError err) 
+lookup
+    :: (AsLookupError err)
     => k -> Map k v -> Either err v
 ```
 
@@ -304,7 +304,7 @@ instance AsParseError ParseError where
     -- etc...
 ```
 
-However, we do have to write our own boilerplate when we eventually want to concretely handle these ttypes.
+However, we do have to write our own boilerplate when we eventually want to concretely handle these types.
 We may end up writing a huge `AppError` that all of these errors get injected into.
 
 There's one major, fatal flaw with this approach.


### PR DESCRIPTION
Dear Matt, thanks to your blog I just learned about the existence of `PatternSynonyms`. Playing with the code and reading about them in GHC user guide I discovered that your definition is a [bidirectional pattern synonym](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#extension-PatternSynonyms) which DOES allow construction of values bu using the pattern in expressions.
Changing this to unidirectional synonym to conform to the surrounding text. Also fixing a compiler issue and a typo. Please accept this PR as a token of my gratitude for your writings :-)

Edit also fixed a couple of random typos highlighted by my spellchecker while scanning through your blog posts. The removal of whitespace in code blocks was done automatically by my editor and hopefully won't bother you :)