### PR TITLE
fpcomplete link is broken, replace it with with schoolofhaskell

### DIFF
--- a/_posts/2015-11-29-an_intuition_on_context_ii.markdown
+++ b/_posts/2015-11-29-an_intuition_on_context_ii.markdown
@@ -60,7 +60,7 @@ Thinking of a function as a container is pretty difficult, and there are other f
 First, why isn't `Set` a valid functor?
 A Set is an unordered collection of elements where duplicates are discarded.
 "Duplicates are discarded" sounds like a likely plan of attack!
-[Michael Snoyman's code snippet](https://www.fpcomplete.com/user/chad/snippets/random-code-snippets/set-is-not-a-functor) shows the simplest case.
+[Michael Snoyman's code snippet](https://www.schoolofhaskell.com/user/chad/snippets/random-code-snippets/set-is-not-a-functor) shows the simplest case.
 This violation of the Functor laws is enough to say that a Set can't be a functor, despite being a container.
 
 Now, for the function functors!


### PR DESCRIPTION
Link to Michael Snoyman’s code snippet on fpcomplete: https://www.fpcomplete.com/user/chad/snippets/random-code-snippets/set-is-not-a-functor is brokne.

But there is such snippet in SchoolOfHaskell:  https://www.schoolofhaskell.com/user/chad/snippets/random-code-snippets/set-is-not-a-functor