### PR TITLE
Fix two minor typos

### DIFF
--- a/_posts/2016-10-26-grokking_fix.markdown
+++ b/_posts/2016-10-26-grokking_fix.markdown
@@ -242,7 +242,7 @@ As it type checks, it also ensures that no variables are undeclared.
 Since `x` is declared in the `let` block, and `f x` is well typed, it accepts this definition.
 
 Haskell will continue applying `f` to `x` each time we demand the next bit of evaluation, or alternatively, whenever `f` self-terminates.
-We saw above that `fix id` dug a big whole of `id` applications, from which we'd never get out.
+We saw above that `fix id` dug a big hole of `id` applications, from which we'd never get out.
 But specializing to a function type allowed us to provide a starting point, and terminate early!
 
 # The Secret Tricks

--- a/_posts/2017-07-27-inverted_mocking.markdown
+++ b/_posts/2017-07-27-inverted_mocking.markdown
@@ -43,7 +43,7 @@ I bet we can simplify our solution to testing.
 # Decomposing Effects
 
 The first thing we need to do is recognize that *effects* and *values* are separate, and try to keep them as separate as possible.
-This is a basic principle of purely functional programming, and we would be wise to take it's heed.
+This is a basic principle of purely functional programming, and we would be wise to take its heed.
 Generally speaking, functions that look like:
 
 ```haskell


### PR DESCRIPTION
`s/whole/hole`
`s/it's/its`

Thanks for the very well-written, entertaining and pedagogically valuable articles!