### PR TITLE
Don't expose the record selector

### DIFF
--- a/_posts/2017-10-11-type_safety_back_and_forth.markdown
+++ b/_posts/2017-10-11-type_safety_back_and_forth.markdown
@@ -76,14 +76,18 @@ We'll take advantage of Haskell's `PatternSynonyms` language extension to allow 
 {-# LANGUAGE PatternSynonyms #-}
 
 module NonZero
-  ( NonZero(unNonZero)
+  ( NonZero()
   , pattern NonZero
+  , unNonZero
   , nonZero
   ) where
 
-newtype NonZero a = UnsafeNonZero { unNonZero :: a }
+newtype NonZero a = UnsafeNonZero a
 
 pattern NonZero a <- UnsafeNonZero a
+
+unNonZero :: NonZero a -> a
+unNonZero (UnsafeNonZero a) = a
 
 nonZero :: (Num a, Eq a) => a -> Maybe (NonZero a)
 nonZero 0 = Nothing


### PR DESCRIPTION
If you expose the record selector, then this program crashes at runtime with a divide by zero error:
```haskell
import NonZero
safeDivide i (NonZero j) = i `div` j
main = case nonZero 1 of
    Nothing -> putStrLn "One is zero?"
    Just one -> do
        let zero = one{ unNonZero = 0 }
        print $ safeDivide 1 zero
```