### PR TITLE
fix typo in 2017-07-27-inverted_mocking.markdown

### DIFF
--- a/_posts/2017-07-27-inverted_mocking.markdown
+++ b/_posts/2017-07-27-inverted_mocking.markdown
@@ -94,7 +94,7 @@ doWorkHelper users = do
   things'users <- for users $ \user -> do
     thing <- getSomething user
     pure (thing, user)
-  lookMaNoInputs thing'users
+  lookMaNoInputs things'users
 
 lookMaNoInputs :: [(Thing, User)] -> App ()
 lookMaNoInputs things'users =


### PR DESCRIPTION
This was missing an `s`. It should refer to the argument initialized on the line above.